### PR TITLE
Upgrade gson to version 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,112 +1,163 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-        
-    <modelVersion>4.0.0</modelVersion>
-        
-    <groupId>io.threatrix.threatmatrix</groupId>
-        
-    <artifactId>threat-matrix-2</artifactId>
-        
-    <version>1.0-SNAPSHOT</version>
-        
-    <properties>
-                
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                
-        <maven-compiler-plugin.source>1.9</maven-compiler-plugin.source>
-                
-        <maven-compiler-plugin.target>1.9</maven-compiler-plugin.target>
-                
-        <maven.compiler.source>1.9</maven.compiler.source>
-                
-        <maven.compiler.target>1.9</maven.compiler.target>
             
+    
+    <modelVersion>4.0.0</modelVersion>
+            
+    
+    <groupId>io.threatrix.threatmatrix</groupId>
+            
+    
+    <artifactId>threat-matrix-2</artifactId>
+            
+    
+    <version>1.0-SNAPSHOT</version>
+            
+    
+    <properties>
+                        
+        
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                        
+        
+        <maven-compiler-plugin.source>1.9</maven-compiler-plugin.source>
+                        
+        
+        <maven-compiler-plugin.target>1.9</maven-compiler-plugin.target>
+                        
+        
+        <maven.compiler.source>1.9</maven.compiler.source>
+                        
+        
+        <maven.compiler.target>1.9</maven.compiler.target>
+                    
+    
     </properties>
-        
+            
+    
     <dependencies>
-                     
+                             
+        
         
         <dependency>
-                        
+                                    
+            
             <groupId>org.springframework.boot</groupId>
-                        
+                                    
+            
             <artifactId>spring-boot-starter-test</artifactId>
-                        
+                                    
+            
             <version>2.1.1.RELEASE</version>
-                        
+                                    
+            
             <exclusions>
-                                
-                <exclusion>
-                                        
-                    <groupId>org.apache.logging.log4j</groupId>
-                                        
-                    <artifactId>log4j-to-slf4j</artifactId>
-                                    
-                </exclusion>
-                                
-                <exclusion>
-                                        
-                    <groupId>ch.qos.logback</groupId>
-                                        
-                    <artifactId>logback-classic</artifactId>
-                                    
-                </exclusion>
-                                
-                <exclusion>
-                                        
-                    <groupId>org.slf4j</groupId>
-                                        
-                    <artifactId>slf4j-log4j12</artifactId>
-                                    
-                </exclusion>
-                                
-                <exclusion>
-                                        
-                    <groupId>log4j</groupId>
-                                        
-                    <artifactId>log4j</artifactId>
-                                    
-                </exclusion>
-                            
-            </exclusions>
-                    
-        </dependency>
+                                                
                 
+                <exclusion>
+                                                            
+                    
+                    <groupId>org.apache.logging.log4j</groupId>
+                                                            
+                    
+                    <artifactId>log4j-to-slf4j</artifactId>
+                                                        
+                
+                </exclusion>
+                                                
+                
+                <exclusion>
+                                                            
+                    
+                    <groupId>ch.qos.logback</groupId>
+                                                            
+                    
+                    <artifactId>logback-classic</artifactId>
+                                                        
+                
+                </exclusion>
+                                                
+                
+                <exclusion>
+                                                            
+                    
+                    <groupId>org.slf4j</groupId>
+                                                            
+                    
+                    <artifactId>slf4j-log4j12</artifactId>
+                                                        
+                
+                </exclusion>
+                                                
+                
+                <exclusion>
+                                                            
+                    
+                    <groupId>log4j</groupId>
+                                                            
+                    
+                    <artifactId>log4j</artifactId>
+                                                        
+                
+                </exclusion>
+                                            
+            
+            </exclusions>
+                                
+        
+        </dependency>
+                        
+        
         
         <dependency>
-                        
+                                    
+            
             <groupId>com.fasterxml.jackson.core</groupId>
-                        
+                                    
+            
             <artifactId>jackson-databind</artifactId>
-                        
+                                    
+            
             <version>2.15.2</version>
-                    
+                                
+        
         </dependency>
-                
+                        
+        
         <dependency>
-                        
+                                    
+            
             <groupId>com.rabbitmq</groupId>
-                        
+                                    
+            
             <artifactId>amqp-client</artifactId>
-                        
+                                    
+            
             <version>5.5.1</version>
-                    
+                                
+        
         </dependency>
-                     
+                             
 
          
+        
         <dependency>
-                         
+                                     
+            
             <groupId>com.netflix.servo</groupId>
-                         
+                                     
+            
             <artifactId>servo-core</artifactId>
-                         
+                                     
+            
             <version>0.13.2</version>
-                     
+                                 
+        
         </dependency>
-                     
+                             
              
 
+        
         <!--
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
@@ -114,212 +165,316 @@
              <version>2.14.1</version>
          </dependency>
 -->
-                     
+                             
+        
         
         <dependency>
-                        
+                                    
+            
             <groupId>org.apache.jena</groupId>
-                        
+                                    
+            
             <artifactId>apache-jena-libs</artifactId>
-                        
+                                    
+            
             <version>3.9.0</version>
-                        
+                                    
+            
             <type>pom</type>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>org.apache.jena</groupId>
-                        
-            <artifactId>jena-iri</artifactId>
-                        
-            <version>3.9.0</version>
-                        
-            <type>jar</type>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>org.antlr</groupId>
-                        
-            <artifactId>antlr</artifactId>
-                        
-            <version>3.4</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>org.apache.poi</groupId>
-                        
-            <artifactId>poi</artifactId>
-                        
-            <version>3.17</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>org.apache.poi</groupId>
-                        
-            <artifactId>poi-ooxml</artifactId>
-                        
-            <version>3.17</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>net.sf.opencsv</groupId>
-                        
-            <artifactId>opencsv</artifactId>
-                        
-            <version>2.3</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>nu.validator.htmlparser</groupId>
-                        
-            <artifactId>htmlparser</artifactId>
-                        
-            <version>1.4</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>net.sf.saxon</groupId>
-                        
-            <artifactId>saxon</artifactId>
-                        
-            <version>8.7</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>org.jsoup</groupId>
-                        
-            <artifactId>jsoup</artifactId>
-                        
-            <version>1.7.2</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>com.github.spullara.mustache.java</groupId>
-                        
-            <artifactId>compiler</artifactId>
-                        
-            <version>0.7.9</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>com.google.code.gson</groupId>
-                        
-            <artifactId>gson</artifactId>
-                        
-            <version>2.8.0</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>net.sf.saxon</groupId>
-                        
-            <artifactId>saxon-dom</artifactId>
-                        
-            <version>8.7</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>com.github.cliftonlabs</groupId>
-                        
-            <artifactId>json-simple</artifactId>
-                        
-            <version>2.3.1</version>
-                    
-        </dependency>
-                
-        <dependency>
-                        
-            <groupId>me.xdrop</groupId>
-                        
-            <artifactId>fuzzywuzzy</artifactId>
-                        
-            <version>1.2.0</version>
-                    
-        </dependency>
-            
-    </dependencies>
+                                
         
-    <build>
-                
-        <sourceDirectory>src/main/java</sourceDirectory>
-                
-        <plugins>
+        </dependency>
                         
-            <plugin>
-                                
-                <artifactId>maven-compiler-plugin</artifactId>
-                                
-                <version>3.5.1</version>
-                                
-                <configuration>
-                                        
-                    <compilerVersion>1.8</compilerVersion>
-                                        
-                    <source>${maven-compiler-plugin.source}</source>
-                                        
-                    <target>${maven-compiler-plugin.target}</target>
+        
+        <dependency>
                                     
-                </configuration>
-                            
-            </plugin>
-                        
-            <plugin>
-                                
-                <groupId>org.springframework.boot</groupId>
-                                
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                                
-                <version>2.1.6.RELEASE</version>
-                                
-                <executions>
-                                        
-                    <execution>
-                                                
-                        <id>repackage</id>
-                                                
-                        <goals>
-                                                        
-                            <goal>repackage</goal>
-                                                    
-                        </goals>
-                                                
-                        <configuration>
-                                                        
-                            <classifier>exec</classifier>
-                                                    
-                        </configuration>
-                                            
-                    </execution>
-                                    
-                </executions>
-                            
-            </plugin>
-                    
-        </plugins>
             
-    </build>
+            <groupId>org.apache.jena</groupId>
+                                    
+            
+            <artifactId>jena-iri</artifactId>
+                                    
+            
+            <version>3.9.0</version>
+                                    
+            
+            <type>jar</type>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>org.antlr</groupId>
+                                    
+            
+            <artifactId>antlr</artifactId>
+                                    
+            
+            <version>3.4</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>org.apache.poi</groupId>
+                                    
+            
+            <artifactId>poi</artifactId>
+                                    
+            
+            <version>3.17</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>org.apache.poi</groupId>
+                                    
+            
+            <artifactId>poi-ooxml</artifactId>
+                                    
+            
+            <version>3.17</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>net.sf.opencsv</groupId>
+                                    
+            
+            <artifactId>opencsv</artifactId>
+                                    
+            
+            <version>2.3</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>nu.validator.htmlparser</groupId>
+                                    
+            
+            <artifactId>htmlparser</artifactId>
+                                    
+            
+            <version>1.4</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>net.sf.saxon</groupId>
+                                    
+            
+            <artifactId>saxon</artifactId>
+                                    
+            
+            <version>8.7</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>org.jsoup</groupId>
+                                    
+            
+            <artifactId>jsoup</artifactId>
+                                    
+            
+            <version>1.7.2</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>com.github.spullara.mustache.java</groupId>
+                                    
+            
+            <artifactId>compiler</artifactId>
+                                    
+            
+            <version>0.7.9</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>com.google.code.gson</groupId>
+                                    
+            
+            <artifactId>gson</artifactId>
+                                    
+            
+            <version>2.8.9</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>net.sf.saxon</groupId>
+                                    
+            
+            <artifactId>saxon-dom</artifactId>
+                                    
+            
+            <version>8.7</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>com.github.cliftonlabs</groupId>
+                                    
+            
+            <artifactId>json-simple</artifactId>
+                                    
+            
+            <version>2.3.1</version>
+                                
+        
+        </dependency>
+                        
+        
+        <dependency>
+                                    
+            
+            <groupId>me.xdrop</groupId>
+                                    
+            
+            <artifactId>fuzzywuzzy</artifactId>
+                                    
+            
+            <version>1.2.0</version>
+                                
+        
+        </dependency>
+                    
     
+    </dependencies>
+            
+    
+    <build>
+                        
+        
+        <sourceDirectory>src/main/java</sourceDirectory>
+                        
+        
+        <plugins>
+                                    
+            
+            <plugin>
+                                                
+                
+                <artifactId>maven-compiler-plugin</artifactId>
+                                                
+                
+                <version>3.5.1</version>
+                                                
+                
+                <configuration>
+                                                            
+                    
+                    <compilerVersion>1.8</compilerVersion>
+                                                            
+                    
+                    <source>${maven-compiler-plugin.source}</source>
+                                                            
+                    
+                    <target>${maven-compiler-plugin.target}</target>
+                                                        
+                
+                </configuration>
+                                            
+            
+            </plugin>
+                                    
+            
+            <plugin>
+                                                
+                
+                <groupId>org.springframework.boot</groupId>
+                                                
+                
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                                                
+                
+                <version>2.1.6.RELEASE</version>
+                                                
+                
+                <executions>
+                                                            
+                    
+                    <execution>
+                                                                        
+                        
+                        <id>repackage</id>
+                                                                        
+                        
+                        <goals>
+                                                                                    
+                            
+                            <goal>repackage</goal>
+                                                                                
+                        
+                        </goals>
+                                                                        
+                        
+                        <configuration>
+                                                                                    
+                            
+                            <classifier>exec</classifier>
+                                                                                
+                        
+                        </configuration>
+                                                                    
+                    
+                    </execution>
+                                                        
+                
+                </executions>
+                                            
+            
+            </plugin>
+                                
+        
+        </plugins>
+                    
+    
+    </build>
+        
+
 </project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades gson to 2.8.9 to fix vulnerabilities in current version